### PR TITLE
fix(ci): slack-workflow-statusをnode24対応フォークに切り替え

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -91,7 +91,7 @@ jobs:
     name: post slack
     runs-on: ubuntu-latest
     steps:
-      - uses: swfz/slack-workflow-status@feature/follow-workflow-run-event
+      - uses: swfz/slack-workflow-status@v1.4.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/webhook.yml
+++ b/.github/workflows/webhook.yml
@@ -15,7 +15,7 @@ jobs:
     name: post slack
     runs-on: ubuntu-latest
     steps:
-      - uses: Gamesight/slack-workflow-status@master
+      - uses: swfz/slack-workflow-status@v1.4.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/workflow-status-notification.yml
+++ b/.github/workflows/workflow-status-notification.yml
@@ -32,7 +32,7 @@ jobs:
     name: workflow notification to slack
     runs-on: ubuntu-latest
     steps:
-      - uses: Gamesight/slack-workflow-status@master
+      - uses: swfz/slack-workflow-status@v1.4.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/workflow_run.yml
+++ b/.github/workflows/workflow_run.yml
@@ -29,7 +29,7 @@ jobs:
           echo $GITHUB_RUN_ID
           echo ${{ steps.get_run_id.outputs.run_id }}
 
-      - uses: swfz/slack-workflow-status@feature/follow-workflow-run-event
+      - uses: swfz/slack-workflow-status@v1.4.0
         id: slack
         env:
           ACTIONS_STEP_DEBUG: true


### PR DESCRIPTION
## Summary
- `Gamesight/slack-workflow-status` or `swfz/slack-workflow-status@feature/*` → `swfz/slack-workflow-status@v1.4.0` に変更
- Node.js 20 deprecation対応（2026年6月2日からNode.js 24が強制デフォルト）
- フォーク側で `action.yml` の `using: node20` → `node24` に更新済み

## Test plan
- [ ] CIが正常に動作すること
- [ ] Slack通知が届くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)