### PR TITLE
chore: sync renovate config from github-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,22 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "osvVulnerabilityAlerts": true,
   "labels": ["renovate"],
   "github-actions": {
-    "fileMatch": [".github/workflows/blank.yml",".github/workflows/takeover-output.yml"]
+    "fileMatch": [".github/workflows/blank.yml", ".github/workflows/takeover-output.yml"]
   },
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["sample.yml"],
       "matchStrings": ["version: (?<depName>.*?)@(?<currentValue>.*?)\n"],
       "datasourceTemplate": "github-tags"
     },
     {
+      "customType": "regex",
       "fileMatch": ["versions.yml"],
       "matchStrings": [
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\n.*?_version: (?<currentValue>.*)\n"
@@ -20,14 +24,15 @@
       "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
     },
     {
-      "fileMatch": [".github/workflows/blank.yml",".github/workflows/takeover-output.yml"],
+      "customType": "regex",
+      "fileMatch": [".github/workflows/blank.yml", ".github/workflows/takeover-output.yml"],
       "matchStrings": ["uses: (?<depName>.*?)@(?<currentValue>.*?)\n"],
       "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [
     {
-      "packageNames": ["actions/checkout"],
+      "matchPackageNames": ["actions/checkout"],
       "versioning": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?"
     }
   ]


### PR DESCRIPTION
Automated file sync by gh-infra FileSet `swfz/article-search+article-search-updater+child-english-study+chrome-extension-copy-markdown-and-hatenablog-embed-link+chrome-extension-dom-links-extractor+chrome-extension-google-slide-usertool-comment-stream+chrome-extension-raindrop-pocket+chrome-extension-slide-comment-stream+chrome-extension-table2csv+claude-bridge+deno-kusa-image+deno-kv-logviewer+deno-logviewer-import-dataform+deno-terminal-image+dotfiles+failed-log-to-slack-action+gh-action-sample+gh-annotations+gh-ap+gh-deps+git-hooks+github-actions-playground+github-actions-sample+github-projects-import-dataform+googleslide-comme-stream-develop+hatenablog-all-feed-generator+hatenablog_publisher+markdown-sentence-sentiment+memo+memo-collector+memo-dataform+metrics-collector+myself-release-note+notion-import-dataform+obsidian-dataform+obsidian-opener+obsidian-vault+pocket-exporter-dataform+pokego-gym-defence+pokego-to-lv80+private-portal+scraping-codes+self-dashboard+self-dashboard-dataform+slack-to-obsidian-memos-merge+swfz+til+til-collector+timetracker+timetracker-dataform+toggl-to-pixela-cloud-workflows+tools+what_recent`.